### PR TITLE
download and extract Vault using archive.extracted

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -1,5 +1,6 @@
 vault:
   vault_version: 0.7.0
+  source_hash: c6d97220e75335f75bd6f603bb23f1f16fe8e2a9d850ba59599b1a0e4d067aaa
   listen_protocol: tcp
   listen_port: 8200
   listen_address: 0.0.0.0

--- a/vault/init.sls
+++ b/vault/init.sls
@@ -1,18 +1,8 @@
-vault packages:
-  pkg.installed:
-    - names:
-      - unzip
-      - curl
-
-download vault:
-  cmd.run:
-    - name: curl --silent -L https://releases.hashicorp.com/vault/{{ pillar['vault']['vault_version'] }}/vault_{{ pillar['vault']['vault_version'] }}_linux_amd64.zip -o /tmp/vault.zip
-    - unless: test -e /tmp/vault.zip
-
-install vault:
-  cmd.run:
-    - name:  unzip /tmp/vault.zip -d /usr/local/bin &&  chmod 0755 /usr/local/bin/vault &&  chown root:root /usr/local/bin/vault
-    - require:
-      - cmd: download vault
-      - pkg: unzip
-    - unless: test -e /usr/local/bin/vault
+{%- set version = salt.pillar.get('vault:vault_version', '0.7.0') %}
+{%- set source_hash = salt.pillar.get('vault:source_hash', 'c6d97220e75335f75bd6f603bb23f1f16fe8e2a9d850ba59599b1a0e4d067aaa') %}
+install Vault:
+  archive.extracted:
+    - name: /usr/local/bin
+    - source: https://releases.hashicorp.com/vault/{{ version }}/vault_{{ version }}_linux_amd64.zip
+    - source_hash: {{ source_hash }}
+    - enforce_toplevel: False


### PR DESCRIPTION
I have tested `archive.extracted` in my own Debian environment. Added `vault.source_hash` pillar and adapted from my own code. This PR has not been tested.