### PR TITLE
Let the server run as non root

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -14,3 +14,5 @@ vault:
   dev_mode: true
   service:
     type: upstart
+  user: root
+  group: root

--- a/vault/defaults.yaml
+++ b/vault/defaults.yaml
@@ -15,3 +15,5 @@ vault:
   dev_mode: true
   service:
     type: systemd
+  user: root
+  group: root

--- a/vault/files/vault_systemd.service.jinja
+++ b/vault/files/vault_systemd.service.jinja
@@ -8,3 +8,5 @@ After=network-online.target consul.service
 EnvironmentFile=-/etc/sysconfig/vault
 Restart=on-failure
 ExecStart=/usr/local/bin/vault server {% if vault.dev_mode %}-dev{% else %} -config="/etc/vault/config/server.hcl"{% endif %}
+User={{ vault.user }}
+Group={{ vault.group }}

--- a/vault/init.sls
+++ b/vault/init.sls
@@ -13,8 +13,14 @@ download vault:
 
 install vault:
   cmd.run:
-    - name:  unzip /tmp/vault.zip -d /usr/local/bin &&  chmod 0755 /usr/local/bin/vault &&  chown root:root /usr/local/bin/vault
+    - name: unzip /tmp/vault.zip -d /usr/local/bin && chmod 0755 /usr/local/bin/vault && chown root:root /usr/local/bin/vault
     - require:
       - cmd: download vault
       - pkg: unzip
     - unless: test -e /usr/local/bin/vault
+
+vault set cap mlock:
+  cmd.run:
+    - name: "setcap cap_ipc_lock=+ep /usr/local/bin/vault"
+    - watch:
+      - cmd: install vault

--- a/vault/init.sls
+++ b/vault/init.sls
@@ -22,5 +22,5 @@ install vault:
 vault set cap mlock:
   cmd.run:
     - name: "setcap cap_ipc_lock=+ep /usr/local/bin/vault"
-    - watch:
+    - onchanges:
       - cmd: install vault


### PR DESCRIPTION
Adds the ability to run the vault server as non-root.

If the server runs as non-root we need to give it the ability to use mlock (see https://www.vaultproject.io/docs/configuration/index.html).