### PR TITLE
Rename strict_tls to tls_disable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ To use it, just include *vault.server* in your *top.sls*, and configure it using
     listen_protocol: tcp
     listen_port: 8200
     listen_address: 0.0.0.0
-    strict_tls: 0
+    tls_disable: 0
     default_lease_ttl: 24h
     max_lease_ttl: 24h
     self_signed_cert:

--- a/pillar.example
+++ b/pillar.example
@@ -3,7 +3,7 @@ vault:
   listen_protocol: tcp
   listen_port: 8200
   listen_address: 0.0.0.0
-  strict_tls: 0
+  tls_disable: 0
   tls_cert_file: {}
   tls_key_file: {}
   default_lease_ttl: 4380h

--- a/vault/defaults.yaml
+++ b/vault/defaults.yaml
@@ -3,7 +3,7 @@ vault:
   listen_protocol: tcp
   listen_port: 8200
   listen_address: 0.0.0.0
-  strict_tls: 0
+  tls_disable: 0
   service: upstart
   tls_cert_file: {}
   tls_key_file: {}

--- a/vault/files/server.hcl.jinja
+++ b/vault/files/server.hcl.jinja
@@ -7,7 +7,7 @@ backend "s3" {
 
 listener "{{ vault.listen_protocol }}" {
   address = "{{ vault.listen_address }}:{{ vault.listen_port }}"
-  tls_disable = {{ vault.strict_tls }}
+  tls_disable = {{ vault.tls_disable }}
 {% if vault.self_signed_cert.enabled %}
   tls_cert_file = "/etc/vault/{{ vault.self_signed_cert.hostname }}.pem"
   tls_key_file = "/etc/vault/{{ vault.self_signed_cert.hostname }}-nopass.key"


### PR DESCRIPTION
The key vault.strict_tls was used to set the vault tls_disable configuration, which is exactle the opposite of strict tls...
I've renamed the configuration key to properly reflect its meaning.