### PR TITLE
Corrected version pillar. This was vault_version, should be valt:version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ To use it, just include *vault.server* in your *top.sls*, and configure it using
 ::
 
   vault:
-    vault_version: 0.7.0
+    version: 0.7.0
     listen_protocol: tcp
     listen_port: 8200
     listen_address: 0.0.0.0


### PR DESCRIPTION
…is. Corrected this in the readme