### PR TITLE
Secure download

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -24,7 +24,10 @@ platforms:
       provision_command:
         - apt-get update && apt-get install -y locales && locale-gen en_US.UTF-8
       run_command: /sbin/init
-      privileged: true
+      pid_one_command: /usr/lib/systemd/systemd
+  - name: centos-7
+    driver_config:
+      run_command: /sbin/init
       pid_one_command: /usr/lib/systemd/systemd
   - name: amazonlinux
     driver_config:

--- a/pillar.example
+++ b/pillar.example
@@ -12,7 +12,40 @@ vault:
     enabled: false
   backend: {}
   dev_mode: true
+  secure_download: true
   service:
     type: upstart
   user: root
   group: root
+  hashicorp_gpg_key: |
+    -----BEGIN PGP PUBLIC KEY BLOCK-----
+    Version: GnuPG v1
+
+    mQENBFMORM0BCADBRyKO1MhCirazOSVwcfTr1xUxjPvfxD3hjUwHtjsOy/bT6p9f
+    W2mRPfwnq2JB5As+paL3UGDsSRDnK9KAxQb0NNF4+eVhr/EJ18s3wwXXDMjpIifq
+    fIm2WyH3G+aRLTLPIpscUNKDyxFOUbsmgXAmJ46Re1fn8uKxKRHbfa39aeuEYWFA
+    3drdL1WoUngvED7f+RnKBK2G6ZEpO+LDovQk19xGjiMTtPJrjMjZJ3QXqPvx5wca
+    KSZLr4lMTuoTI/ZXyZy5bD4tShiZz6KcyX27cD70q2iRcEZ0poLKHyEIDAi3TM5k
+    SwbbWBFd5RNPOR0qzrb/0p9ksKK48IIfH2FvABEBAAG0K0hhc2hpQ29ycCBTZWN1
+    cml0eSA8c2VjdXJpdHlAaGFzaGljb3JwLmNvbT6JATgEEwECACIFAlMORM0CGwMG
+    CwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEFGFLYc0j/xMyWIIAIPhcVqiQ59n
+    Jc07gjUX0SWBJAxEG1lKxfzS4Xp+57h2xxTpdotGQ1fZwsihaIqow337YHQI3q0i
+    SqV534Ms+j/tU7X8sq11xFJIeEVG8PASRCwmryUwghFKPlHETQ8jJ+Y8+1asRydi
+    psP3B/5Mjhqv/uOK+Vy3zAyIpyDOMtIpOVfjSpCplVRdtSTFWBu9Em7j5I2HMn1w
+    sJZnJgXKpybpibGiiTtmnFLOwibmprSu04rsnP4ncdC2XRD4wIjoyA+4PKgX3sCO
+    klEzKryWYBmLkJOMDdo52LttP3279s7XrkLEE7ia0fXa2c12EQ0f0DQ1tGUvyVEW
+    WmJVccm5bq25AQ0EUw5EzQEIANaPUY04/g7AmYkOMjaCZ6iTp9hB5Rsj/4ee/ln9
+    wArzRO9+3eejLWh53FoN1rO+su7tiXJA5YAzVy6tuolrqjM8DBztPxdLBbEi4V+j
+    2tK0dATdBQBHEh3OJApO2UBtcjaZBT31zrG9K55D+CrcgIVEHAKY8Cb4kLBkb5wM
+    skn+DrASKU0BNIV1qRsxfiUdQHZfSqtp004nrql1lbFMLFEuiY8FZrkkQ9qduixo
+    mTT6f34/oiY+Jam3zCK7RDN/OjuWheIPGj/Qbx9JuNiwgX6yRj7OE1tjUx6d8g9y
+    0H1fmLJbb3WZZbuuGFnK6qrE3bGeY8+AWaJAZ37wpWh1p0cAEQEAAYkBHwQYAQIA
+    CQUCUw5EzQIbDAAKCRBRhS2HNI/8TJntCAClU7TOO/X053eKF1jqNW4A1qpxctVc
+    z8eTcY8Om5O4f6a/rfxfNFKn9Qyja/OG1xWNobETy7MiMXYjaa8uUx5iFy6kMVaP
+    0BXJ59NLZjMARGw6lVTYDTIvzqqqwLxgliSDfSnqUhubGwvykANPO+93BBx89MRG
+    unNoYGXtPlhNFrAsB1VR8+EyKLv2HQtGCPSFBhrjuzH3gxGibNDDdFQLxxuJWepJ
+    EK1UbTS4ms0NgZ2Uknqn1WRU1Ki7rE4sTy68iZtWpKQXZEJa0IGnuI2sSINGcXCJ
+    oEIgXTMyCILo34Fa/C6VCm2WBgz9zZO8/rHIiQm1J5zqz0DrDwKBUM9C
+    =LYpS
+    -----END PGP PUBLIC KEY BLOCK-----
+  hashicorp_key_id: 51852D87348FFC4C

--- a/vault/defaults.yaml
+++ b/vault/defaults.yaml
@@ -1,5 +1,5 @@
 vault:
-  version: 0.7.0
+  version: 0.9.1
   listen_protocol: tcp
   listen_port: 8200
   listen_address: 0.0.0.0

--- a/vault/defaults.yaml
+++ b/vault/defaults.yaml
@@ -13,7 +13,40 @@ vault:
     enabled: false
   backend: {}
   dev_mode: true
+  secure_download: true
   service:
     type: systemd
   user: root
   group: root
+  hashicorp_gpg_key: |
+    -----BEGIN PGP PUBLIC KEY BLOCK-----
+    Version: GnuPG v1
+
+    mQENBFMORM0BCADBRyKO1MhCirazOSVwcfTr1xUxjPvfxD3hjUwHtjsOy/bT6p9f
+    W2mRPfwnq2JB5As+paL3UGDsSRDnK9KAxQb0NNF4+eVhr/EJ18s3wwXXDMjpIifq
+    fIm2WyH3G+aRLTLPIpscUNKDyxFOUbsmgXAmJ46Re1fn8uKxKRHbfa39aeuEYWFA
+    3drdL1WoUngvED7f+RnKBK2G6ZEpO+LDovQk19xGjiMTtPJrjMjZJ3QXqPvx5wca
+    KSZLr4lMTuoTI/ZXyZy5bD4tShiZz6KcyX27cD70q2iRcEZ0poLKHyEIDAi3TM5k
+    SwbbWBFd5RNPOR0qzrb/0p9ksKK48IIfH2FvABEBAAG0K0hhc2hpQ29ycCBTZWN1
+    cml0eSA8c2VjdXJpdHlAaGFzaGljb3JwLmNvbT6JATgEEwECACIFAlMORM0CGwMG
+    CwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEFGFLYc0j/xMyWIIAIPhcVqiQ59n
+    Jc07gjUX0SWBJAxEG1lKxfzS4Xp+57h2xxTpdotGQ1fZwsihaIqow337YHQI3q0i
+    SqV534Ms+j/tU7X8sq11xFJIeEVG8PASRCwmryUwghFKPlHETQ8jJ+Y8+1asRydi
+    psP3B/5Mjhqv/uOK+Vy3zAyIpyDOMtIpOVfjSpCplVRdtSTFWBu9Em7j5I2HMn1w
+    sJZnJgXKpybpibGiiTtmnFLOwibmprSu04rsnP4ncdC2XRD4wIjoyA+4PKgX3sCO
+    klEzKryWYBmLkJOMDdo52LttP3279s7XrkLEE7ia0fXa2c12EQ0f0DQ1tGUvyVEW
+    WmJVccm5bq25AQ0EUw5EzQEIANaPUY04/g7AmYkOMjaCZ6iTp9hB5Rsj/4ee/ln9
+    wArzRO9+3eejLWh53FoN1rO+su7tiXJA5YAzVy6tuolrqjM8DBztPxdLBbEi4V+j
+    2tK0dATdBQBHEh3OJApO2UBtcjaZBT31zrG9K55D+CrcgIVEHAKY8Cb4kLBkb5wM
+    skn+DrASKU0BNIV1qRsxfiUdQHZfSqtp004nrql1lbFMLFEuiY8FZrkkQ9qduixo
+    mTT6f34/oiY+Jam3zCK7RDN/OjuWheIPGj/Qbx9JuNiwgX6yRj7OE1tjUx6d8g9y
+    0H1fmLJbb3WZZbuuGFnK6qrE3bGeY8+AWaJAZ37wpWh1p0cAEQEAAYkBHwQYAQIA
+    CQUCUw5EzQIbDAAKCRBRhS2HNI/8TJntCAClU7TOO/X053eKF1jqNW4A1qpxctVc
+    z8eTcY8Om5O4f6a/rfxfNFKn9Qyja/OG1xWNobETy7MiMXYjaa8uUx5iFy6kMVaP
+    0BXJ59NLZjMARGw6lVTYDTIvzqqqwLxgliSDfSnqUhubGwvykANPO+93BBx89MRG
+    unNoYGXtPlhNFrAsB1VR8+EyKLv2HQtGCPSFBhrjuzH3gxGibNDDdFQLxxuJWepJ
+    EK1UbTS4ms0NgZ2Uknqn1WRU1Ki7rE4sTy68iZtWpKQXZEJa0IGnuI2sSINGcXCJ
+    oEIgXTMyCILo34Fa/C6VCm2WBgz9zZO8/rHIiQm1J5zqz0DrDwKBUM9C
+    =LYpS
+    -----END PGP PUBLIC KEY BLOCK-----
+  hashicorp_key_id: 51852D87348FFC4C

--- a/vault/files/hashicorp.asc.jinja
+++ b/vault/files/hashicorp.asc.jinja
@@ -1,0 +1,2 @@
+{%- from "vault/map.jinja" import vault with context -%}
+{{ vault.hashicorp_gpg_key }}

--- a/vault/init.sls
+++ b/vault/init.sls
@@ -53,7 +53,7 @@ verify shasums sig:
 
 verify vault:
   cmd.run:
-    - name: "shasum -a 256 -c vault_{{ vault.version }}_SHA256SUMS | grep -q \"vault_{{ vault.version }}_linux_amd64.zip: OK\""
+    - name: "shasum -a 256 -c vault_{{ vault.version }}_SHA256SUMS 2>&1 | grep -q \"vault_{{ vault.version }}_linux_amd64.zip: OK\""
     - cwd: /tmp
     - require:
       - cmd: download vault

--- a/vault/init.sls
+++ b/vault/init.sls
@@ -5,19 +5,71 @@ vault packages:
     - names:
       - unzip
       - curl
+      {% if vault.secure_download %}
+      {% if grains['os'] == 'CentOS' or grains['os'] == 'Amazon' %}
+      - gnupg2
+      - perl-Digest-SHA
+      {% elif grains['os'] == 'Ubuntu' %}
+      - gnupg
+      - libdigest-sha-perl
+      {% endif %}
+      {% endif %}
 
 download vault:
   cmd.run:
-    - name: curl --silent -L https://releases.hashicorp.com/vault/{{ vault.version }}/vault_{{ vault.version }}_linux_amd64.zip -o /tmp/vault.zip
-    - unless: test -e /tmp/vault.zip
+    - name: curl --silent -L https://releases.hashicorp.com/vault/{{ vault.version }}/vault_{{ vault.version }}_linux_amd64.zip -o /tmp/vault_{{ vault.version }}_linux_amd64.zip
+    - creates: /tmp/vault_{{ vault.version }}_linux_amd64.zip
+
+{% if vault.secure_download %}
+download shasums:
+  cmd.run:
+    - name: curl --silent -L https://releases.hashicorp.com/vault/{{ vault.version }}/vault_{{ vault.version }}_SHA256SUMS -o /tmp/vault_{{ vault.version }}_SHA256SUMS
+    - creates: /tmp/vault_{{ vault.version }}_SHA256SUMS
+
+download shasums sig:
+  cmd.run:
+    - name: curl --silent -L https://releases.hashicorp.com/vault/{{ vault.version }}/vault_{{ vault.version }}_SHA256SUMS.sig -o /tmp/vault_{{ vault.version }}_SHA256SUMS.sig
+    - creates: /tmp/vault_{{ vault.version }}_SHA256SUMS.sig
+
+/tmp/hashicorp.asc:
+  file.managed:
+    - source: salt://vault/files/hashicorp.asc.jinja
+    - template: jinja
+
+import key:
+  cmd.run:
+    - name: gpg --import /tmp/hashicorp.asc
+    - unless: gpg --list-keys {{ vault.hashicorp_key_id }}
+    - requires:
+      - file: /tmp/hashicorp.asc
+      - cmd: vault packages
+
+verify shasums sig:
+  cmd.run:
+    - name: gpg --verify /tmp/vault_{{ vault.version }}_SHA256SUMS.sig /tmp/vault_{{ vault.version }}_SHA256SUMS
+    - require:
+      - cmd: download shasums
+      - cmd: import key
+
+verify vault:
+  cmd.run:
+    - name: "shasum -a 256 -c vault_{{ vault.version }}_SHA256SUMS | grep -q \"vault_{{ vault.version }}_linux_amd64.zip: OK\""
+    - cwd: /tmp
+    - require:
+      - cmd: download vault
+      - cmd: verify shasums sig
+{% endif %}
 
 install vault:
   cmd.run:
-    - name: unzip /tmp/vault.zip -d /usr/local/bin && chmod 0755 /usr/local/bin/vault && chown root:root /usr/local/bin/vault
+    - name: unzip /tmp/vault_{{ vault.version }}_linux_amd64.zip -d /usr/local/bin && chmod 0755 /usr/local/bin/vault && chown root:root /usr/local/bin/vault
     - require:
       - cmd: download vault
       - pkg: unzip
-    - unless: test -e /usr/local/bin/vault
+      {% if vault.secure_download %}
+      - cmd: verify vault
+      {% endif %}
+    - creates: /usr/local/bin/vault
 
 vault set cap mlock:
   cmd.run:

--- a/vault/server.sls
+++ b/vault/server.sls
@@ -70,3 +70,6 @@ vault:
       - cmd: generate self signed SSL certs
       {% endif -%}
       - file: /etc/vault/config/server.hcl
+    - onchanges:
+      - cmd: install vault
+      - file: /etc/vault/config/server.hcl


### PR DESCRIPTION
This PR has overlap with #7, but only implements the GPG and sha256 verification of the downloaded Vault binaries.

Along the run, I also disabled the `privileged` attribute as this should not be required and the cause of [several bug reports](https://github.com/moby/moby/issues/4040) on Docker related projects dealing with `systemd`.

I also added a CentOS test suite and some glue around that since this is my target platform. That said, I might have to come back with another PR for `selinux` and `firewalld`.

This is my first time writing Salt states ever, be gentle. :)