### PR TITLE
kitchen: fix amazon image and inspec declaration

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,7 +6,6 @@ driver:
 
 verifier:
   name: inspec
-  format: doc
 
 provisioner:
   name: salt_solo
@@ -33,7 +32,7 @@ platforms:
     driver_config:
       provision_command:
         - yum install -y epel-release
-      image: amazonlinux:latest
+      image: amazonlinux:1
       platform: rhel
       run_command: /sbin/init
 


### PR DESCRIPTION
amazonlinux:latest pulls in AMI 2 which salt bootstrap doesn't support

format: doc is deprecated