### PR TITLE
feat(yamllint): include for this repo and apply rules throughout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 ---
 stages:
   - test
-  - commitlint
+  - lint
   - name: release
     if: branch = master AND type != pull_request
 
@@ -45,16 +45,21 @@ script:
 
 jobs:
   include:
-    # Define the commitlint stage
-    - stage: commitlint
+    # Define the `lint` stage (runs `yamllint` and `commitlint`)
+    - stage: lint
       language: node_js
       node_js: lts/*
       before_install: skip
       script:
+        # Install and run `yamllint`
+        - pip install --user yamllint
+        # yamllint disable-line rule:line-length
+        - yamllint -s . .yamllint pillar.example test/salt/pillar/install_binary.sls test/salt/pillar/dev_server.sls test/salt/pillar/prod_server.sls
+        # Install and run `commitlint`
         - npm install @commitlint/config-conventional -D
         - npm install @commitlint/travis-cli -D
         - commitlint-travis
-    # Define the release stage that runs semantic-release
+    # Define the release stage that runs `semantic-release`
     - stage: release
       language: node_js
       node_js: lts/*

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
+# Extend the `default` configuration provided by `yamllint`
+extends: default
+
+# Files to ignore completely
+# 1. All YAML files under directory `node_modules/`, introduced during the Travis run
+ignore: |
+  node_modules/
+
+rules:
+  line-length:
+    # Increase from default of `80`
+    # Based on https://github.com/PyCQA/flake8-bugbear#opinionated-warnings (`B950`)
+    max: 88

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -17,7 +17,8 @@ platforms:
       platform: rhel
       run_command: /sbin/init
       provision_command:
-        - curl -L https://bootstrap.saltstack.com | sh -s -- -X     # install latest stable Salt
+        # install latest stable Salt
+        - curl -L https://bootstrap.saltstack.com | sh -s -- -X
 
   ## SALT `develop`
   - name: debian-9-develop-py3

--- a/pillar.example
+++ b/pillar.example
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
-# vim: ft=sls syntax=yaml softtabstop=2 tabstop=2 shiftwidth=2 expandtab autoindent
-
+# vim: ft=yaml
+---
 vault:
   version: 1.1.0
   platform: linux_amd64
-  dev_mode: False
-  verify_download: True
+  dev_mode: false
+  verify_download: true
   config:
     storage:
       consul:
@@ -51,4 +51,3 @@ vault:
     oEIgXTMyCILo34Fa/C6VCm2WBgz9zZO8/rHIiQm1J5zqz0DrDwKBUM9C
     =LYpS
     -----END PGP PUBLIC KEY BLOCK-----
-

--- a/test/integration/dev_server/inspec.yml
+++ b/test/integration/dev_server/inspec.yml
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 name: dev_server
 title: vault formula
 maintainer: SaltStack Formulas

--- a/test/integration/install_binary/inspec.yml
+++ b/test/integration/install_binary/inspec.yml
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 name: install_binary
 title: vault formula
 maintainer: SaltStack Formulas

--- a/test/integration/prod_server/inspec.yml
+++ b/test/integration/prod_server/inspec.yml
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 name: prod_server
 title: vault formula
 maintainer: SaltStack Formulas

--- a/test/salt/pillar/dev_server.sls
+++ b/test/salt/pillar/dev_server.sls
@@ -1,2 +1,5 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 vault:
-  dev_mode: True
+  dev_mode: true

--- a/test/salt/pillar/install_binary.sls
+++ b/test/salt/pillar/install_binary.sls
@@ -1,4 +1,9 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 vault:
-  # version: 1.0.3    # test upgrades by doing a double-converge, changing the version pillar between each one
+  # test upgrades by doing a double-converge, changing the version pillar
+  # between each one
+  # version: 1.0.3
   version: 1.1.0
-  verify_download: False
+  verify_download: false

--- a/test/salt/pillar/prod_server.sls
+++ b/test/salt/pillar/prod_server.sls
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 vault:
   config:
     storage:
@@ -5,7 +8,7 @@ vault:
         path: /var/lib/vault/data
   tls_disable: 1
   self_signed_cert:
-    enabled: True
+    enabled: true
     hostname: localhost
     password: localhost
     country: GB

--- a/vault/defaults.yaml
+++ b/vault/defaults.yaml
@@ -1,15 +1,15 @@
 # -*- coding: utf-8 -*-
-# vim: ft=sls syntax=yaml softtabstop=2 tabstop=2 shiftwidth=2 expandtab autoindent
-
+# vim: ft=yaml
+---
 vault:
   version: 1.1.0
   platform: linux_amd64
   gpg_pkg: gnupg2
   setcap_pkg: libcap
-  dev_mode: False
-  verify_download: True
+  dev_mode: false
+  verify_download: true
   self_signed_cert:
-    enabled: False
+    enabled: false
   config:
     listener:
       tcp:

--- a/vault/initfamilymap.yaml
+++ b/vault/initfamilymap.yaml
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# vim: ft=sls syntax=yaml softtabstop=2 tabstop=2 shiftwidth=2 expandtab autoindent
-
+# vim: ft=yaml
+---
 systemd:
   service:
     path: /etc/systemd/system/vault.service

--- a/vault/osfamilymap.yaml
+++ b/vault/osfamilymap.yaml
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# vim: ft=sls syntax=yaml softtabstop=2 tabstop=2 shiftwidth=2 expandtab autoindent
-
+# vim: ft=yaml
+---
 Debian:
   setcap_pkg: libcap2-bin
 


### PR DESCRIPTION
* Semi-automated using `ssf-formula` (v0.5.0)
* Fix errors shown below:

```bash
vault-formula$ $(grep "\- yamllint" .travis.yml | sed -e "s:^\s\+-\s\(.*\):\1:")
./kitchen.yml
  20:89     error    line too long (96 > 88 characters)  (line-length)

./vault/defaults.yaml
  4:1       warning  missing document start "---"  (document-start)
  9:13      warning  truthy value should be one of [false, true]  (truthy)
  10:20     warning  truthy value should be one of [false, true]  (truthy)
  12:14     warning  truthy value should be one of [false, true]  (truthy)

./vault/osfamilymap.yaml
  4:1       warning  missing document start "---"  (document-start)

./vault/initfamilymap.yaml
  4:1       warning  missing document start "---"  (document-start)

pillar.example
  4:1       warning  missing document start "---"  (document-start)
  7:13      warning  truthy value should be one of [false, true]  (truthy)
  8:20      warning  truthy value should be one of [false, true]  (truthy)
  54:1      error    too many blank lines (1 > 0)  (empty-lines)

test/salt/pillar/install_binary.sls
  1:1       warning  missing document start "---"  (document-start)
  2:89      error    line too long (110 > 88 characters)  (line-length)
  4:20      warning  truthy value should be one of [false, true]  (truthy)

test/salt/pillar/dev_server.sls
  1:1       warning  missing document start "---"  (document-start)
  2:13      warning  truthy value should be one of [false, true]  (truthy)

test/salt/pillar/prod_server.sls
  1:1       warning  missing document start "---"  (document-start)
  8:14      warning  truthy value should be one of [false, true]  (truthy)
```

---

Refer back to: https://github.com/saltstack-formulas/template-formula/pull/159#issue-305203039.