### PR TITLE
ci(kitchen): change `log_level` to `debug` instead of `info`

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -141,7 +141,7 @@ platforms:
 
 provisioner:
   name: salt_solo
-  log_level: info
+  log_level: debug
   salt_install: none
   require_chef: false
   formula: vault


### PR DESCRIPTION
* Automated using https://github.com/myii/ssf-formula/pull/41

---

This commit was pushed automatically to the other 41 `semantic-release` formulas.  That wasn't possible here due to the repo settings.