### PR TITLE
ci(kitchen): use bootstrapped `opensuse` images until `2019.2.2`

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -47,11 +47,13 @@ platforms:
         - sh bootstrap-salt.sh -XdPbfrq -x python3 git develop
   - name: opensuse-leap-15-develop-py3
     driver:
-      image: netmanagers/salt-develop-py3:opensuse-leap-15
+      image: opensuse/leap:15
       provision_command:
-        - curl -o bootstrap-salt.sh -L https://bootstrap.saltstack.com
-        - sh bootstrap-salt.sh -XdPbfrq -x python3 git develop
+        - systemctl enable sshd.service
       run_command: /usr/lib/systemd/systemd
+    provisioner:
+      salt_bootstrap_options: -XdPfrq -x python3 git develop
+      salt_install: bootstrap
     # Workaround to avoid intermittent failures on `opensuse-leap-15`:
     # => SCP did not finish successfully (255):  (Net::SCP::Error)
     transport:
@@ -85,8 +87,13 @@ platforms:
       image: netmanagers/salt-2019.2-py3:fedora-30
   - name: opensuse-leap-15-2019-2-py3
     driver:
-      image: netmanagers/salt-2019.2-py3:opensuse-leap-15
+      image: opensuse/leap:15
+      provision_command:
+        - systemctl enable sshd.service
       run_command: /usr/lib/systemd/systemd
+    provisioner:
+      salt_bootstrap_options: -XdPfrq -x python3 git 2019.2
+      salt_install: bootstrap
     # Workaround to avoid intermittent failures on `opensuse-leap-15`:
     # => SCP did not finish successfully (255):  (Net::SCP::Error)
     transport:
@@ -114,8 +121,13 @@ platforms:
       image: netmanagers/salt-2018.3-py2:fedora-29
   - name: opensuse-leap-15-2018-3-py2
     driver:
-      image: netmanagers/salt-2018.3-py2:opensuse-leap-15
+      image: opensuse/leap:15
+      provision_command:
+        - systemctl enable sshd.service
       run_command: /usr/lib/systemd/systemd
+    provisioner:
+      salt_bootstrap_options: -XdPfrq -x python2 git 2018.3
+      salt_install: bootstrap
     # Workaround to avoid intermittent failures on `opensuse-leap-15`:
     # => SCP did not finish successfully (255):  (Net::SCP::Error)
     transport:
@@ -144,8 +156,13 @@ platforms:
       image: netmanagers/salt-2017.7-py2:fedora-29
   - name: opensuse-leap-15-2017-7-py2
     driver:
-      image: netmanagers/salt-2017.7-py2:opensuse-leap-15
+      image: opensuse/leap:15
+      provision_command:
+        - systemctl enable sshd.service
       run_command: /usr/lib/systemd/systemd
+    provisioner:
+      salt_bootstrap_options: -XdPfrq -x python2 git 2017.7
+      salt_install: bootstrap
     # Workaround to avoid intermittent failures on `opensuse-leap-15`:
     # => SCP did not finish successfully (255):  (Net::SCP::Error)
     transport:

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -49,6 +49,8 @@ platforms:
     driver:
       image: opensuse/leap:15
       provision_command:
+        # yamllint disable-line rule:line-length
+        - zypper install -y glibc-locale net-tools net-tools-deprecated python-xml python3-pip
         - systemctl enable sshd.service
       run_command: /usr/lib/systemd/systemd
     provisioner:
@@ -89,6 +91,8 @@ platforms:
     driver:
       image: opensuse/leap:15
       provision_command:
+        # yamllint disable-line rule:line-length
+        - zypper install -y glibc-locale net-tools net-tools-deprecated python-xml python3-pip
         - systemctl enable sshd.service
       run_command: /usr/lib/systemd/systemd
     provisioner:
@@ -123,6 +127,8 @@ platforms:
     driver:
       image: opensuse/leap:15
       provision_command:
+        # yamllint disable-line rule:line-length
+        - zypper install -y glibc-locale net-tools net-tools-deprecated python-xml python2-pip
         - systemctl enable sshd.service
       run_command: /usr/lib/systemd/systemd
     provisioner:
@@ -158,6 +164,8 @@ platforms:
     driver:
       image: opensuse/leap:15
       provision_command:
+        # yamllint disable-line rule:line-length
+        - zypper install -y glibc-locale net-tools net-tools-deprecated python-xml python2-pip
         - systemctl enable sshd.service
       run_command: /usr/lib/systemd/systemd
     provisioner:


### PR DESCRIPTION
* Automated using https://github.com/myii/ssf-formula/pull/52
* Updated using https://github.com/myii/ssf-formula/pull/53