### PR TITLE
ci(kitchen+travis): use bootstrapped `amazonlinux-1` images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,7 @@ jobs:
     ## Define the rest of the matrix based on Kitchen testing
     # Make sure the instances listed below match up with
     # the `platforms` defined in `kitchen.yml`
+    # - env: INSTANCE=amazonlinux-1-master-py2
     - env: INSTANCE=debian-10-master-py3
     # - env: INSTANCE=ubuntu-1804-master-py3
     # - env: INSTANCE=centos-8-master-py3
@@ -68,6 +69,7 @@ jobs:
     # - env: INSTANCE=opensuse-leap-151-master-py3
     # - env: INSTANCE=amazonlinux-2-master-py2
     # - env: INSTANCE=arch-base-latest-master-py2
+    # - env: INSTANCE=amazonlinux-1-2019-2-py2
     # - env: INSTANCE=debian-10-2019-2-py3
     # - env: INSTANCE=debian-9-2019-2-py3
     - env: INSTANCE=prod-server-ubuntu-1804-2019-2-py3
@@ -78,12 +80,14 @@ jobs:
     - env: INSTANCE=prod-server-amazonlinux-2-2019-2-py2
     # - env: INSTANCE=arch-base-latest-2019-2-py2
     # - env: INSTANCE=fedora-30-2018-3-py3
+    # - env: INSTANCE=amazonlinux-1-2018-3-py2
     # - env: INSTANCE=debian-9-2018-3-py2
     # - env: INSTANCE=ubuntu-1604-2018-3-py2
     - env: INSTANCE=prod-server-centos-7-2018-3-py2
     - env: INSTANCE=prod-server-opensuse-leap-151-2018-3-py2
     # - env: INSTANCE=amazonlinux-2-2018-3-py2
     # - env: INSTANCE=arch-base-latest-2018-3-py2
+    # - env: INSTANCE=amazonlinux-1-2017-7-py2
     # - env: INSTANCE=debian-8-2017-7-py2
     # - env: INSTANCE=ubuntu-1604-2017-7-py2
     # - env: INSTANCE=centos-6-2017-7-py2

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -11,16 +11,14 @@ driver:
 # Make sure the platforms listed below match up with
 # the `env.matrix` instances defined in `.travis.yml`
 platforms:
-  - name: amazonlinux
+  ## SALT `master`
+  - name: amazonlinux-1-master-py2
     driver:
       image: amazonlinux:1
-      platform: rhel
-      run_command: /sbin/init
       provision_command:
-        # install latest stable Salt
-        - curl -L https://bootstrap.saltstack.com | sh -s -- -X
-
-  ## SALT `master`
+        - curl -o bootstrap-salt.sh -L https://bootstrap.saltstack.com
+        - sh bootstrap-salt.sh -XdPfq -x python2 git master
+      run_command: /sbin/init
   - name: debian-10-master-py3
     driver:
       image: netmanagers/salt-master-py3:debian-10
@@ -73,6 +71,13 @@ platforms:
       run_command: /usr/lib/systemd/systemd
 
   ## SALT `2019.2`
+  - name: amazonlinux-1-2019-2-py2
+    driver:
+      image: amazonlinux:1
+      provision_command:
+        - curl -o bootstrap-salt.sh -L https://bootstrap.saltstack.com
+        - sh bootstrap-salt.sh -XdPfq -x python2 git 2019.2
+      run_command: /sbin/init
   - name: debian-10-2019-2-py3
     driver:
       image: netmanagers/salt-2019.2-py3:debian-10
@@ -111,6 +116,13 @@ platforms:
   - name: fedora-30-2018-3-py3
     driver:
       image: netmanagers/salt-2018.3-py3:fedora-30
+  - name: amazonlinux-1-2018-3-py2
+    driver:
+      image: amazonlinux:1
+      provision_command:
+        - curl -o bootstrap-salt.sh -L https://bootstrap.saltstack.com
+        - sh bootstrap-salt.sh -XdPfq -x python2 git 2018.3
+      run_command: /sbin/init
   - name: debian-9-2018-3-py2
     driver:
       image: netmanagers/salt-2018.3-py2:debian-9
@@ -137,6 +149,13 @@ platforms:
       run_command: /usr/lib/systemd/systemd
 
   ## SALT `2017.7`
+  - name: amazonlinux-1-2017-7-py2
+    driver:
+      image: amazonlinux:1
+      provision_command:
+        - curl -o bootstrap-salt.sh -L https://bootstrap.saltstack.com
+        - sh bootstrap-salt.sh -XdPfq -x python2 git 2017.7
+      run_command: /sbin/init
   - name: debian-8-2017-7-py2
     driver:
       image: netmanagers/salt-2017.7-py2:debian-8


### PR DESCRIPTION
* Automated using https://github.com/myii/ssf-formula/pull/94

---

@dafyddj Needed `amazonlinux-1` for the `epel-formula` so took this opportunity to standardise the way bootstrapped images are provided by the `ssf-formula`.  Up to now, it's been using an inline `if` block solely for the `vault-formula`; now it can provide `amazonlinux-1` to formulas in the same way as pre-salted images.

I've tested all of these across all three suites (and the combined one) here:

* https://travis-ci.org/myii/vault-formula/builds/607049255