### PR TITLE
refactor: make `cert-gen.sh` POSIX-compatible

### DIFF
--- a/vault/files/cert-gen.sh.j2
+++ b/vault/files/cert-gen.sh.j2
@@ -1,13 +1,13 @@
 {% from "vault/map.jinja" import vault with context -%}
 {% set vssc = vault.self_signed_cert -%}
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 ###
  # Check for root name.
  ##
 root=$1
 shift
-if [[ -z "$root" ]]; then
+if [ -z "$root" ]; then
   echo "you must pass 2 arguments; first for root name, second for child name"
   exit
 fi
@@ -16,7 +16,7 @@ fi
  # Check for child name
  ##
 child=$1
-if [[ -z "$child" ]]; then
+if [ -z "$child" ]; then
   echo "you must pass 2 arguments; first for root name ($root), second for child name"
   exit
 fi
@@ -38,7 +38,7 @@ root_p12="$root.p12"
 ###
  # Generate the root private key
  ##
-if [[ -e "$root_key" ]]; then
+if [ -e "$root_key" ]; then
   echo "$root_key already exits"
 else
   echo "generate $root_key"
@@ -48,7 +48,7 @@ fi
 ###
  # Genereate the the root privacy enhanced email (PEM)
  ##
-if [[ -e "$root_pem" ]]; then
+if [ -e "$root_pem" ]; then
   echo "$root_pem already exits"
 else
   echo "generate $root_pem"
@@ -58,7 +58,7 @@ fi
 ###
  # Generate the root public key (P12)
  ##
-if [[ -e "$root_p12" ]]; then
+if [ -e "$root_p12" ]; then
   echo "$root_p12 already exits"
 else
   echo "generate $root_p12"
@@ -80,7 +80,7 @@ child_jks="$child_name.jks"
 ###
  # Generate the child private key
  ##
-if [[ -e "$child_key" ]]; then
+if [ -e "$child_key" ]; then
   echo "$child_key already exits"
 else
   echo "generate $child_key"
@@ -88,9 +88,9 @@ else
 fi
 
 ###
- # Genereate the the child privacy enhanced email (PEM)
+ # Generate the the child privacy enhanced email (PEM)
  ##
-if [[ -e "$child_pem" ]]; then
+if [ -e "$child_pem" ]; then
   echo "$child_pem already exits"
 else
   echo "generate $child_csr"
@@ -103,7 +103,7 @@ fi
 ###
  # Generate the child public key (P12)
  ##
-if [[ -e "$child_p12" ]]; then
+if [ -e "$child_p12" ]; then
   echo "$child_p12 already exits"
 else
   echo "generate $child_p12"
@@ -114,11 +114,11 @@ fi
 ###
  # Generate the Java Keystore (JKS)
  ##
-if [[ -e "$child_jks" ]]; then
+if [ -e "$child_jks" ]; then
   echo "$child_jks already exits"
 else
   keytool="keytool"
-  if [[ -n $(command -v $keytool) ]]; then
+  if [ -n "$(command -v $keytool)" ]; then
     echo "generate $child_jks with $root trustedCertEntry"
     $keytool -importcert -trustcacerts -noprompt -file "$root_pem" -destkeystore "$child_jks" -storepass "$pw" \
       -alias "$root" -v


### PR DESCRIPTION
<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [x] Changes to documentation are appropriate (or tick if not required)
- [x] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [ ] `[feat]`     A new feature
- [ ] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [x] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->



### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

Make `cert-gen.sh` POSIX-compatible using `sh` rather than `bash` for portability.
Can't guarantee that a potential minion will have `bash` installed.

### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->



### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->



### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [x] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


